### PR TITLE
backoffice_권한페이지

### DIFF
--- a/src/components/backoffice/roles/RolesContent.tsx
+++ b/src/components/backoffice/roles/RolesContent.tsx
@@ -1,10 +1,173 @@
-const RolesContent = () => {
-	return (
-		<div className="flex flex-col gap-4">
-			<h1 className="text-2xl font-bold">권한</h1>
-			<p className="text-muted-foreground">권한 관리 페이지입니다.</p>
-		</div>
-	)
-}
+'use client';
 
-export default RolesContent;
+import { useState } from "react";
+import { Trash2, Edit } from "lucide-react";
+
+const PermissionManagementPage = () => {
+  // 상태 관리
+  const [permissionCurrentPage, setPermissionCurrentPage] = useState(1);
+  const [selectedUsers, setSelectedUsers] = useState<string[]>([]);
+  const [showPermissionEditModal, setShowPermissionEditModal] = useState(false);
+  const [editingUser, setEditingUser] = useState<any>(null);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [deleteItemId, setDeleteItemId] = useState<string | null>(null);
+
+  // 더미 데이터
+  const permissionUsers = [
+    { id: "qlwkdnfd11", permission: "대표" },
+    { id: "wlwnfkdlw12", permission: "대표" },
+    { id: "qlwkdnfd11", permission: "대표" },
+    { id: "wlwnfkdlw12", permission: "대표" },
+    { id: "qlwkdnfd11", permission: "대표" },
+    { id: "wlwnfkdlw12", permission: "대표" },
+    { id: "qlwkdnfd11", permission: "대표" },
+    { id: "wlwnfkdlw12", permission: "대표" },
+    { id: "qlwkdnfd11", permission: "대표" },
+    { id: "wlwnfkdlw12", permission: "대표" },
+  ];
+
+  const permissionItemsPerPage = 10;
+  const permissionTotalPages = Math.ceil(permissionUsers.length / permissionItemsPerPage);
+  const permissionStartIndex = (permissionCurrentPage - 1) * permissionItemsPerPage;
+  const currentPermissionUsers = permissionUsers.slice(permissionStartIndex, permissionStartIndex + permissionItemsPerPage);
+
+  // 핸들러 함수들
+  const handlePermissionChange = (userId: string, newPermission: string) => {
+    alert(`${userId}의 권한이 ${newPermission}로 변경되었습니다`);
+  };
+
+  const handlePermissionEdit = (user: any) => {
+    setEditingUser(user);
+    setShowPermissionEditModal(true);
+  };
+
+  const handlePermissionDelete = (userId: string) => {
+    setDeleteItemId(userId);
+    setShowDeleteModal(true);
+  };
+
+  const handlePermissionPageClick = (page: number) => {
+    setPermissionCurrentPage(page);
+  };
+
+  return (
+    <div className="flex min-h-screen bg-[#F8F9FA]">
+      {/* 기존 사이드바 영역을 삭제했습니다.
+      */}
+
+      {/* 메인 콘텐츠 */}
+      <div className="flex-1">
+        {/* 헤더 */}
+        <div className="bg-white border-b border-[#E5E7EB] px-8 py-6">
+          <div className="flex items-center justify-between">
+            <h1 className="text-[28px] font-bold text-[#111416]">권한 관리</h1>
+            {/*
+              기존의 우측 상단 고객센터 영역을 삭제했습니다.
+            */}
+          </div>
+        </div>
+
+        {/* 테이블 영역 */}
+        <div className="px-8 py-6">
+          <div className="bg-white rounded-lg border border-[#E5E7EB] overflow-hidden">
+            {/* 테이블 */}
+            <table className="w-full">
+              <thead>
+                <tr className="border-b border-[#E5E7EB]">
+                  {/* ID 열 너비를 60%로 확장 */}
+                  <th className="text-left px-6 py-4 text-[12px] font-bold text-[#6B7280] uppercase tracking-wider w-[60%]">
+                    ID
+                  </th>
+                  {/* 권한 열 너비를 20%로 축소 */}
+                  <th className="text-left px-6 py-4 text-[12px] font-bold text-[#6B7280] uppercase tracking-wider w-[20%]">
+                    권한
+                  </th>
+                  {/* 작업 열 너비를 20%로 축소 */}
+                  <th className="text-center px-6 py-4 text-[12px] font-bold text-[#6B7280] uppercase tracking-wider w-[20%]">
+                    작업
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {currentPermissionUsers.map((user, index) => (
+                  <tr 
+                    key={`${user.id}-${index}`} 
+                    className={`border-b border-[#F3F4F6] ${index % 2 === 1 ? 'bg-[#F9FAFB]' : 'bg-white'}`}
+                  >
+                    {/* ID 컬럼: 헤더와 같은 정렬로 변경 */}
+                    <td className="px-6 py-5 text-left">
+                      <span className="text-[14px] text-[#111827] font-medium">{user.id}</span>
+                    </td>
+
+                    {/* 권한 드롭다운 컬럼: 헤더와 같은 정렬로 변경 */}
+                    <td className="px-6 py-5 text-left">
+                      <div className="relative inline-block">
+                        <select
+                          className="appearance-none bg-white border border-[#D1D5DB] rounded-md px-4 py-2 pr-10 text-[14px] text-[#374151] focus:outline-none focus:ring-2 focus:ring-[#3B82F6] focus:border-transparent shadow-sm min-w-[100px]"
+                          value={user.permission}
+                          onChange={(e) => handlePermissionChange(user.id, e.target.value)}
+                        >
+                          <option value="대표">대표</option>
+                          <option value="관리자">관리자</option>
+                          <option value="직원">직원</option>
+                          <option value="인턴">인턴</option>
+                        </select>
+                        <div className="absolute inset-y-0 right-0 flex items-center px-2 pointer-events-none">
+                          <svg className="w-4 h-4 text-[#9CA3AF]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7"></path>
+                          </svg>
+                        </div>
+                      </div>
+                    </td>
+
+                    {/* 작업 버튼 컬럼: 헤더와 같은 정렬로 변경 */}
+                    <td className="px-6 py-5 text-center">
+                      <div className="flex items-center justify-center gap-3">
+                        <button
+                          className="w-10 h-10 flex items-center justify-center hover:bg-[#F3F4F6] rounded-lg transition-colors"
+                          onClick={() => handlePermissionDelete(`${user.id}-${index}`)}
+                        >
+                          <Trash2 className="w-5 h-5 text-[#6B7280]" />
+                        </button>
+                        <button
+                          className="w-10 h-10 flex items-center justify-center hover:bg-[#F3F4F6] rounded-lg transition-colors"
+                          onClick={() => handlePermissionEdit(user)}
+                        >
+                          <Edit className="w-5 h-5 text-[#6B7280]" />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+
+            {/* 페이지네이션 */}
+            <div className="px-6 py-5 bg-white border-t border-[#F3F4F6]">
+              <div className="flex justify-center">
+                <div className="flex items-center gap-1">
+                  {[1, 2, 3, "...", 8, 9, 10].map((page, index) => (
+                    <button
+                      key={index}
+                      className={`px-3 py-2 text-sm font-medium transition-colors ${
+                        page === permissionCurrentPage 
+                          ? "text-[#111827] text-base" 
+                          : "text-[#6B7280] text-sm hover:text-[#374151]"
+                      }`}
+                      onClick={() => typeof page === "number" && handlePermissionPageClick(page)}
+                      disabled={typeof page !== "number"}
+                    >
+                      {page}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PermissionManagementPage;


### PR DESCRIPTION
backoffice_권한페이지 UI 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 새로운 권한 관리 페이지 도입(헤더: “권한 관리”).
  - 사용자 권한 테이블(열: ID, 권한, 작업) 제공.
  - 행별 드롭다운으로 권한 변경, 편집/삭제 액션 버튼 제공.
  - 숫자·말줄임표 기반 페이지네이션으로 사용자 목록 탐색 지원.

- 리팩터링
  - 기존 정적 역할 화면을 대화형 클라이언트 화면으로 전면 교체하여 사용성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->